### PR TITLE
get_field_value_in_info processed badly fields with same beginning

### DIFF
--- a/bioformats/vcf/vcf_util.c
+++ b/bioformats/vcf/vcf_util.c
@@ -20,7 +20,9 @@ char *get_field_value_in_info(const char *field, char *info) {
     
     // Search for field in info (must begin with '<field>=')
     token = strtok_r(info, ";", &save_strtok);
-    while (token != NULL && !starts_with(token, field) && strlen(token) > strlen(field)+1 && token[strlen(field)] == '=') {
+    while (token != NULL && 
+	   (!starts_with(token, field) || // Field is completely different than the requested one
+	   (strlen(token) > strlen(field) && token[strlen(field)] != '='))) { // Same beginning, but longer than the requested one
         token = strtok_r(NULL, ";", &save_strtok);
     }
     


### PR DESCRIPTION
Solved bug that get_field_value_in_info didn't processed correctly fields with the same beginning
